### PR TITLE
Add minimum collect id

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
 								<label class="radio"><input type="radio" class ="form-control" checked="checked" name="primesource"  id = "internetarchive" value="internetarchive" onclick="javascript:yesnoCheck();">Internet Archive</label>&nbsp;
 								<label class="radio"><input type="radio" class ="form-control" name="primesource" id = "archiveit" value="archiveit" onclick="javascript:yesnoCheck();">Archive-It</label>
 								<!--label for="collectionNo">Collection Identifier</label-->
-							  <input class="form-control" type="number" class ="form-control" title="Collection Identifier"  name="ci"  id="collectionNo" placeholder="Collection Identifier" />
+							  <input class="form-control" type="number" min="0" class ="form-control" title="Collection Identifier"  name="ci"  id="collectionNo" placeholder="Collection Identifier" />
 							</div>
 							<!-- THRESHOLD AND DELAY-->
 


### PR DESCRIPTION
Fixes #37. Perhaps a more sophisticated method can be used to equate 0 with the "all" collection (e.g., if so desired) but it does not seem to have sense to allow negative collection numbers in the UI.