### PR TITLE
s/URI-TM/URI-T/g

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
 				<form action="#" class="argumentsForm">
 
 					<div class="row URIWrapper" >
-						<label for="uriIP">Enter URI-R <span class='uriexample'>(ex: http://4genderjustice.org)</span> or  URI-M <span class='uriexample'>(ex: http://wayback.archive-it.org/1068/20150701215641/http://4genderjustice.org/)</span> or URI-TM <span class='uriexample'>(ex: http://web.archive.org/web/timemap/link/http://4genderjustice.org)</span></label>
+						<label for="uriIP">Enter URI-R <span class='uriexample'>(ex: http://4genderjustice.org)</span> or  URI-M <span class='uriexample'>(ex: http://wayback.archive-it.org/1068/20150701215641/http://4genderjustice.org/)</span> or URI-T <span class='uriexample'>(ex: http://web.archive.org/web/timemap/link/http://4genderjustice.org)</span></label>
 							<div class="input-group">
 
 								<input class="form-control" name="URI" id="uriIP" required placeholder="For example, http://4genderjustice.org/">

--- a/public/scripts/timeline.js
+++ b/public/scripts/timeline.js
@@ -678,7 +678,7 @@ function uriAnalysisForAttributes(uri){
       }else if(prePartToURIR.indexOf("archive.org") > -1){
         primesource = "internetarchive";
       }else{
-        alert("not a valid input for URI, pass a valid URI-R || URI-M || URI-TM");
+        alert("not a valid input for URI, pass a valid URI-R || URI-M || URI-T");
         return false;
       }
       $('.argumentsForm #urirIP').val(urir);


### PR DESCRIPTION
The [Memento specification (RFC7089)](https://tools.ietf.org/html/rfc7089) defines `URI-T`, not `URI-TM` to denote the URI of a TimeMap. In two places in this repo, "URI-TM" is used. This PR replaces the two instances with the standard term.