### PR TITLE
Changes to Cache Update process and Major Bug Fix

### DIFF
--- a/public/scripts/histogram.js
+++ b/public/scripts/histogram.js
@@ -374,8 +374,8 @@ function drawHistogram(dateArray){
 
 	    // Adjust dates to histogram domain
 	    from = new Date(from.getFullYear(), from.getMonth(), 1);
-	    toDays = new Date(to.getFullYear(), to.getMonth()+1, 0).getDate();
-	    to = new Date(to.getFullYear(), to.getMonth(), toDays);
+	    toDays = new Date(to.getFullYear(), to.getMonth()+2, 0).getDate();
+	    to = new Date(to.getFullYear(), to.getMonth()+1, toDays);
 
 	    // Adjust month for date string
 	    var fromMonth = from.getMonth()+1;

--- a/public/scripts/timeline.js
+++ b/public/scripts/timeline.js
@@ -1634,8 +1634,8 @@ function isValidDate(dateString)
 
     // Adjust dates to histogram domain
     from = new Date(from.getFullYear(), from.getMonth(), 1);
-    toDays = new Date(to.getFullYear(), to.getMonth()+1, 0).getDate();
-    to = new Date(to.getFullYear(), to.getMonth(), toDays);
+    toDays = new Date(to.getFullYear(), to.getMonth()+2, 0).getDate();
+    to = new Date(to.getFullYear(), to.getMonth()+2, toDays);
 
     // Adjust month for date string
     var fromMonth = from.getMonth()+1;
@@ -1649,7 +1649,7 @@ function isValidDate(dateString)
     month = month - 1;
     
     // Check if input within possible range of mementos
-    if(compareDate < from || compareDate > to) {
+    if(compareDate <= from || compareDate >= to) {
         document.getElementById("date_error").innerHTML = "Please enter dates between " + fromDateStr + " and " + toDateStr;
         return false;
     }

--- a/public/scripts/timeline.js
+++ b/public/scripts/timeline.js
@@ -845,11 +845,7 @@ function getHistoData(toDisplay) {
         $(".time_container").hide();
         $(".Explain_Threshold").hide();
 
-        var numOfMementos = $("#selected_mementos").text();
-        if(numOfMementos.length == 0) {
-            numOfMementos = -1;
-        }
-        var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0" +"/" + numOfMementos + "/" +$('.argumentsForm #urirIP').val().trim();
+        var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0" +"/"+$('.argumentsForm #urirIP').val().trim();
 
         startEventNotification();
 
@@ -955,19 +951,15 @@ function getStats(from, to) {
     if($("body").find("form")[0].checkValidity()) {
         startEventNotification();
         var ENDPOINT = "/alsummarizedtimemap";
-        var numOfMementos = $("#selected_mementos").text();
-        if(numOfMementos.length == 0){
-            numOfMementos = -1;
-        }
         if(from == 0 && to == 0) { // If no dates were passed
-            var address= ENDPOINT+"/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0"+"/" + numOfMementos + "/"+$('.argumentsForm #urirIP').val();
+            var address= ENDPOINT+"/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0"+"/"+$('.argumentsForm #urirIP').val();
             var path = "/alsummarizedview" + "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+$('.argumentsForm #urirIP').val();
         }
         else {
             inputDates = from + "," + to;
             var fromFormatted = from.substring(0,4)+from.substring(5,7)+from.substring(8,10);
             var toFormatted = to.substring(0,4)+to.substring(5,7)+to.substring(8,10);
-            var address= ENDPOINT+"/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+from+"/"+to+"/"+ numOfMementos + "/"+$('.argumentsForm #urirIP').val();
+            var address= ENDPOINT+"/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+from+"/"+to+"/"+$('.argumentsForm #urirIP').val();
             var path = "/alsummarizedview" + "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+fromFormatted+"/"+toFormatted+"/"+$('.argumentsForm #urirIP').val();
         }
 
@@ -1094,18 +1086,14 @@ function getSummary(from, to) {
     if($("body").find("form")[0].checkValidity()) {
         $(".time_container").hide();
         $(".Explain_Threshold").hide();
-        var numOfMementos = $("#selected_mementos").text();
-        if(numOfMementos.length == 0) {
-            numOfMementos = -1;
-        }
         if(from == 0 && to == 0) {
-            var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0"+"/" + numOfMementos + "/"+ $('.argumentsForm #urirIP').val().trim();
+            var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+"0"+"/"+"0"+"/"+ $('.argumentsForm #urirIP').val().trim();
             var summaryPath = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role +"/"+ $('.argumentsForm #urirIP').val().trim();
         }
         else {
             var fromFormatted = from.substring(0,4)+from.substring(5,7)+from.substring(8,10);
             var toFormatted = to.substring(0,4)+to.substring(5,7)+to.substring(8,10);
-            var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+from+"/"+to+"/" + numOfMementos + "/"+ $('.argumentsForm #urirIP').val().trim();
+            var pathForAjaxCall = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+from+"/"+to+"/"+ $('.argumentsForm #urirIP').val().trim();
             var summaryPath = "/"+$('.argumentsForm input[name=primesource]:checked').val()+"/"+collectionIdentifer+"/"+hammingDistance+"/"+role+"/"+fromFormatted+"/"+toFormatted+"/" +$('.argumentsForm #urirIP').val().trim();
         }
 

--- a/tmvis.js
+++ b/tmvis.js
@@ -226,7 +226,7 @@ function main () {
     // this is the actually place that hit the main server logic
     //app.get('/alsummarizedtimemap/:primesource/:ci/:urir', endpoint.respondToClient)
 
-    app.get('/alsummarizedtimemap/:primesource/:ci/:hdt/:role/:from/:to/:numMementos/*', endpoint.respondToClient);
+    app.get('/alsummarizedtimemap/:primesource/:ci/:hdt/:role/:from/:to/*', endpoint.respondToClient);
 
 
     app.listen(port, '0.0.0.0', (err) => {
@@ -428,8 +428,6 @@ function PublicEndpoint() {
             query['from'] = 0;
             query['to'] = 0;
         }
-      
-        query['numMementos'] = request.params.numMementos;
 
         query['ssd']=request.params.ssd;
 
@@ -558,7 +556,6 @@ function PublicEndpoint() {
             response.thumbnails['to'] = 0;
         }
 
-        response.thumbnails['numMementos'] = parseInt(query.numMementos);
         /*TODO: include consideration for strategy parameter supplied here
                 If we consider the strategy, we can simply use the TimeMap instead of the cache file
                 Either way, the 'response' should be passed to the function representing the chosen strategy
@@ -1143,8 +1140,6 @@ Memento.prototype.setSimhash = function (theTimeMap,curCookieClientId,notDateRan
 *                           merges them with fullCachedTimemap and t objects,
 *                           responds to the request appropriately,
 *
-* This function is called based on if the numMementos request parameter matches 
-* the number of mementos from cache file
 *
 * @param fullCachedTimemap - timemap object that holds all mementos from cache file
 * @param t - timemap object that holds all cached mementos with a date range

--- a/tmvis.js
+++ b/tmvis.js
@@ -90,7 +90,7 @@ var Stack = require('stackjs');
 var dateRange = false;
 var mementosFromMultipleURIs = [];
 var archivedMementos = [];
-var maxMementos = 200;
+var maxMementos = 1000;
 //var fullTimemap = new TimeMap(); 
 //return
 /* *******************************
@@ -371,7 +371,6 @@ function PublicEndpoint() {
         ConsoleLogIfRequired(request.headers["x-my-curuniqueusersessionid"]);
         ConsoleLogIfRequired("############################################");
 
-
         responseDup = response;
         ConsoleLogIfRequired("Cookies------------------>"+request.headers["x-my-curuniqueusersessionid"]);
         constructSSE("streamingStarted",request.headers["x-my-curuniqueusersessionid"]);
@@ -633,7 +632,7 @@ function PublicEndpoint() {
 *
 * @param curCookieClientId - current client cookie id
 */
-function writeFullTimemapToCache(curCookieClientId) {
+/*function writeFullTimemapToCache(curCookieClientId) {
     async.series([
         function(callback) {
             fullTimemap.calculateSimhashes(curCookieClientId,false,callback);
@@ -659,7 +658,7 @@ function writeFullTimemapToCache(curCookieClientId) {
             }
         }
     );
-}
+}*/
 
 /**
 * Delete all derived data including caching and screenshot - namely for testing
@@ -852,7 +851,7 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
             if ((t.hammingdistancethreshold == '0' && t.role == "summary") || t.mementos.length == 0 || t.role == "histogram") {
                 callback('');
             } else {
-                t.calculateSimhashes(curCookieClientId,true,callback);
+                t.calculateSimhashes(curCookieClientId,true,response,callback);
             }
         },
         function (callback) {
@@ -1024,7 +1023,7 @@ Memento.prototype.simhashIndicatorForHTTP302 = '00000000';
 * @param theTimemap - the timemap object this memento belong to
 * @param notDateRange - a boolean variable that handles SSEs sent to the front-end
 */
-Memento.prototype.setSimhash = function (theTimeMap,curCookieClientId,notDateRange,callback) {
+Memento.prototype.setSimhash = function (theTimeMap,curCookieClientId,notDateRange,response,callback) {
     // Retain the urir for reference in the promise (this context lost with async)
     var thaturi = this.uri;
     var thatmemento = this;
@@ -1105,6 +1104,9 @@ Memento.prototype.setSimhash = function (theTimeMap,curCookieClientId,notDateRan
                 if(theTimeMap.prevCompletionVal > 100) {
                     theTimeMap.prevCompletionVal = 95;
                 }
+
+                response.write("")
+
                 console.log("theTimeMap completedSimhashedMementoCount -> "+theTimeMap.completedSimhashedMementoCount);
                 if(!notDateRange) {constructSSE("percentagedone-"+Math.ceil(theTimeMap.prevCompletionVal),curCookieClientId);}
 
@@ -1169,7 +1171,7 @@ TimeMap.prototype.updateCache = function(fullCachedTimemap, uri, response, curCo
             updatedTimemap.deleteCachedMementos(t.mementos,callback);
         },
         function(callback) {
-            updatedTimemap.calculateSimhashes(curCookieClientId, true, callback);
+            updatedTimemap.calculateSimhashes(curCookieClientId, true, response, callback);
         },
         function(callback) {
             //merge new mementos new and sort
@@ -1501,7 +1503,7 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
             if (t.role == "histogram" || (t.hammingdistancethreshold == '0' && t.role == "summary")) {
                 callback('');
             } else {
-                t.calculateSimhashes(curCookieClientId,true,callback);
+                t.calculateSimhashes(curCookieClientId,true,response,callback);
             }
         },
         function (callback) {
@@ -1619,7 +1621,7 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
 * @param notDateRange - boolean that handles SSEs sent to the front-end
 * @param callback - The next procedure to execution when this process concludes
 */
-TimeMap.prototype.calculateSimhashes = function (curCookieClientId,notDateRange,callback) {
+TimeMap.prototype.calculateSimhashes = function (curCookieClientId,notDateRange,response,callback) {
     //ConsoleLogIfRequired("--- By Mahee - For my understanding")
     //ConsoleLogIfRequired("Inside CalculateSimhashes")
     var theTimeMap = this;
@@ -1630,7 +1632,7 @@ TimeMap.prototype.calculateSimhashes = function (curCookieClientId,notDateRange,
     // the way to get a damper, just 7 requests at a time.
     async.eachLimit(this.mementos,5, function(curMemento, callback) {
 
-        curMemento.setSimhash(theTimeMap,curCookieClientId,notDateRange,callback);
+        curMemento.setSimhash(theTimeMap,curCookieClientId,notDateRange,response,callback);
         //ConsoleLogIfRequired(curMemento)
     }, function(err) {
         //  ConsoleLogIfRequired("length of arr ayOfSetSimhashFunctions: -> " + arrayOfSetSimhashFunctions.length);
@@ -1819,9 +1821,9 @@ TimeMap.prototype.filterMementos = function(response, curCookieClientId, callbac
             tempStackArchived.push(archivedMementos[i]);
         count++;
         if(count == 4) {
-            if(parts == 50)
+            if(parts == 250)
                 break;
-            i = (originalMemetosLengthFromTM-1) - (Math.floor(originalMemetosLengthFromTM/50)*parts);
+            i = (originalMemetosLengthFromTM-1) - (Math.floor(originalMemetosLengthFromTM/250)*parts);
             count = 0;
             parts++;
         }

--- a/tmvis.js
+++ b/tmvis.js
@@ -1486,7 +1486,7 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
                         }
                        
                        if(t.mementos.length > 5000)
-                          t.filermementos(curCookieClientId);
+                          t.filtermementos(curCookieClientId);
                                
                         if (t.mementos.length == 0) {
                             ConsoleLogIfRequired('There were no mementos in this date range:(');

--- a/tmvis.js
+++ b/tmvis.js
@@ -1486,7 +1486,7 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
                         }
                        
                        if(t.mementos.length > 5000)
-                          t.filtermementos(curCookieClientId);
+                          t.filterMementos(curCookieClientId);
                                
                         if (t.mementos.length == 0) {
                             ConsoleLogIfRequired('There were no mementos in this date range:(');

--- a/tmvis.js
+++ b/tmvis.js
@@ -1484,6 +1484,9 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
                             response.end();
                             return;
                         }
+                       
+                       if(t.mementos.length > 5000)
+                          t.filermementos(curCookieClientId);
                                
                         if (t.mementos.length == 0) {
                             ConsoleLogIfRequired('There were no mementos in this date range:(');
@@ -1535,15 +1538,15 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
     }
 }
 
-TimeMap.prototype.filterMementos = function(uri, curCookieClientId) {
+TimeMap.prototype.filterMementos = function(curCookieClientId) {
     var t = this;
 
     var originalMemetosLengthFromTM = t.mementos.length;
     // code segment to consider only last 1000 mementos for the huge TimeMaps
-    if(t.mementos.length > 1000 && t.role != "histogram") {
+    if(t.mementos.length > 5000 && t.role != "histogram") {
         var tempMemetoArr=[];
         var tempStackOfMementos = new Stack();
-        var numOfMementosToConsider = 1000; // only latest 1000 mementos are considered
+        var numOfMementosToConsider = 5000; // only latest 5000 mementos are considered
         for(var i = originalMemetosLengthFromTM-1; i>(originalMemetosLengthFromTM-numOfMementosToConsider-1); i--) {
             tempStackOfMementos.push(t.mementos[i]);
         }
@@ -1590,12 +1593,6 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
         function(callback) {
             if(response.thumbnails['from'] != 0) {
                 t.mementos = t.filterMementosForDateRange(response);
-            }
-            callback('');
-        },
-        function(callback) {
-            if(response.thumbnails['from'] != 0) {
-                t.filterMementos(uri, curCookieClientId);
             }
             callback('');
         },

--- a/tmvis.js
+++ b/tmvis.js
@@ -1802,7 +1802,7 @@ TimeMap.prototype.filterMementos = function(response, curCookieClientId, callbac
         else {
             currentTime = new Date(t.mementos[i]["datetime"].split(",")[1]).getTime();
             daysBetween = (currentTime - lastTime) / (1000*60*60*24);
-            if(daysBetween >= 3) { //If mementos are at least 7 days apart
+            if(daysBetween >= 3) { //If mementos are at least 3 days apart
                 console.log("Found one --------------------------------------------------- ");
                 console.log(i);
                 tempMementoArr.push(t.mementos[i]);

--- a/tmvis.js
+++ b/tmvis.js
@@ -1543,7 +1543,7 @@ TimeMap.prototype.filterMementos = function(curCookieClientId) {
 
     var originalMemetosLengthFromTM = t.mementos.length;
     // code segment to consider only last 1000 mementos for the huge TimeMaps
-    if(t.mementos.length > 5000 && t.role != "histogram") {
+    if(t.mementos.length > 5000) {
         var tempMemetoArr=[];
         var tempStackOfMementos = new Stack();
         var numOfMementosToConsider = 5000; // only latest 5000 mementos are considered

--- a/tmvis.js
+++ b/tmvis.js
@@ -89,6 +89,8 @@ var Stack = require('stackjs');
 
 var dateRange = false;
 var mementosFromMultipleURIs = [];
+var archivedMementos = [];
+var maxMementos = 1000;
 //var fullTimemap = new TimeMap(); 
 //return
 /* *******************************
@@ -575,13 +577,19 @@ function PublicEndpoint() {
 
         // If more than 1 URI was passed at once, check if each individual URI has been cached.
         // If not, cache it. Then merge the timemaps of each URI for the user.
-        if(URIs.length > 1 && t.role != "histogram") {
+        if(URIs.length > 1) {
             mementosFromMultipleURIs = [];
             processMultipleURIs(t, query, response, request.headers["x-my-curuniqueusersessionid"]);
         } else {
             // TODO: optimize this out of the conditional so the functions needed for each strategy are self-contained (and possibly OOP-ified)
             if (strategy === 'alSummarization') {
-                var cacheFile = new SimhashCacheFile( query.primesource+"_"+query.ci+"_"+urlCanonicalize(query['urir']),isDebugMode);
+                var originalURI = urlCanonicalize(query['urir']);
+                var histogramFile = new SimhashCacheFile(query.primesource+"_"+query.ci+"_"+originalURI,isDebugMode);
+                histogramFile.path = histogramFile.path.replace("simhashes","histogram");
+                histogramFile.path += ".json";
+                archivedMementos = JSON.parse(histogramFile.readFileContentsSync());
+
+                var cacheFile = new SimhashCacheFile( query.primesource+"_"+query.ci+"_"+originalURI,isDebugMode);
                 cacheFile.path += '.json';
                 ConsoleLogIfRequired('Checking if a cache file exists for ' + query['urir'] + '...');
                 constructSSE('Checking if a cache file exists for ' + query['urir'] + '...',request.headers["x-my-curuniqueusersessionid"]);
@@ -693,20 +701,17 @@ function processMultipleURIs(t, query, response, curCookieClientId) {
             checkIfCachedForMultipleURIs(uriList, query, response, curCookieClientId, callback);
         },
         function(callback) {
-            // Check if all requested mementos were cached. If not, update the files.
-            if(response.thumbnails['numMementos'] > mementosFromMultipleURIs.length) {
-                mementosFromMultipleURIs = [];
-                updateCacheForMultipleURIs(uriList, query, response, curCookieClientId, callback);
-            } else {
-                callback('');
-            }
-        },
-        function(callback) {
             t.mementos = t.mementos.concat(mementosFromMultipleURIs);
             if(response.thumbnails['from'] != 0) {
-                t.mementos = t.filterMementosForDateRange(response);
-            }
-            callback('');
+                t.filterMementosForDateRange(response, callback);
+            } else
+                callback('');
+        },
+        function(callback) {
+            if(t.mementos.length > maxMementos && t.role != "histogram") {
+                t.filterMementos(response, curCookieClientId, callback);
+            } else
+                callback('');
         },
         function (callback) {
             if(t.role == "stats") {
@@ -732,7 +737,7 @@ function processMultipleURIs(t, query, response, curCookieClientId) {
             ConsoleLogIfRequired('****************curCookieClientId from processWithFileContents ->'+curCookieClientId +' *********');
             constructSSE("percentagedone-20",curCookieClientId);
             if (t.role == "histogram") {
-                t.getDatesForHistogram(callback,response,curCookieClientId);
+                t.getDatesForHistogram(callback,response,curCookieClientId, null);
             } else {
                 t.createScreenshotsForMementos(curCookieClientId,response,callback);
             }
@@ -764,14 +769,48 @@ function processMultipleURIs(t, query, response, curCookieClientId) {
 */
 function checkIfCachedForMultipleURIs(uriList, query, response, curCookieClientId, callback) {
     async.eachLimit(uriList, 1, function(uri, callback) {
-        var cacheFile = new SimhashCacheFile(query.primesource+"_"+query.ci+"_"+urlCanonicalize(uri),isDebugMode);
+        var originalURI = urlCanonicalize(uri);
+        var cacheFile = new SimhashCacheFile(query.primesource+"_"+query.ci+"_"+originalURI,isDebugMode);
         cacheFile.path += ".json";
-        if (!(fs.existsSync(cacheFile.path))) {
+        if (!(fs.existsSync(cacheFile.path)) || query['role'] == "histogram") {
             getTimemapForMultipleURIs(uri, query, response, curCookieClientId, callback, false);
         } else {
+            var histogramFile = new SimhashCacheFile(query.primesource+"_"+query.ci+"_"+originalURI,isDebugMode);
+            histogramFile.path = histogramFile.path.replace("simhashes","histogram");
+            histogramFile.path += ".json";
+            archivedMementos = JSON.parse(histogramFile.readFileContentsSync());
+
             var data = fs.readFileSync(cacheFile.path, 'utf-8');
-            mementosFromMultipleURIs = mementosFromMultipleURIs.concat(JSON.parse(data));
-            callback();
+            var curTimeMap = createMementosFromJSONFile(data);
+            curTimeMap.originalURI = originalURI;
+            curTimeMap.primesource = query.primesource;
+            curTimeMap.collectionidentifier = query.ci;
+            curTimeMap.hammingdistancethreshold = query.hdt;
+            curTimeMap.role = query.role;
+
+            async.series([
+                function(callback) {
+                    if(response.thumbnails['from'] != 0) {
+                        curTimeMap.filterMementosForDateRange(response, callback);
+                    } else
+                        callback('');
+                },
+                function (callback) {
+                    curTimeMap.matchMementosToArchive(originalURI, response, curCookieClientId, data, callback);
+                },
+                function (callback) {
+                    curTimeMap.getDatesForHistogram(callback,response,curCookieClientId, true);
+                }
+            ],
+                function(err){
+                    if(err) {
+                        console.log(err);
+                        return;
+                    }
+                    mementosFromMultipleURIs = mementosFromMultipleURIs.concat(curTimeMap.mementos);
+                    callback();
+                }
+            );
         }},
         function(err) {
             if(err) {
@@ -800,24 +839,6 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
     var retStr = '';
     var metadata = '';
 
-    if(update) {
-        var cacheFile = new SimhashCacheFile(query.primesource+"_"+query.ci+"_"+urlCanonicalize(uri),isDebugMode);
-        cacheFile.path += ".json";
-        if (!(fs.existsSync(cacheFile.path))) {
-            update = false;
-        } else {
-            var data = fs.readFileSync(cacheFile.path, 'utf-8');
-            var fullCachedTimemap = createMementosFromJSONFile(data);
-            //fullCachedTimemap.mementos = getUnique(mementosFromMultipleURIs, "uri");
-            fullCachedTimemap.curClientId = curCookieClientId;
-            fullCachedTimemap.originalURI = urlCanonicalize(response.thumbnails['urir']);
-            fullCachedTimemap.primesource = response.thumbnails['primesource'];
-            fullCachedTimemap.collectionidentifier = response.thumbnails['collectionidentifier'];
-            fullCachedTimemap.hammingdistancethreshold = response.thumbnails['hammingdistancethreshold'];
-            fullCachedTimemap.role = response.thumbnails['role'];
-        }
-    }
-
     ConsoleLogIfRequired('Starting many asynchronous operationsX...');
 
     async.series([
@@ -825,38 +846,16 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
             t.fetchTimemap(uri, response, curCookieClientId, callback);
         },
         function(callback) {
-            if(update) {
-                t.deleteCachedMementos(data, callback);
-            } else {
-                callback('');
-            }
-        },
-        function(callback) {
             if(response.thumbnails['from'] != 0 && t.mementos.length != 0) {
-                t.mementos = t.filterMementosForDateRange(response);
-            }
-            callback('');
+                t.filterMementosForDateRange(response, callback);
+            } else
+                callback('');
         },
         function (callback) {
-            if ((t.hammingdistancethreshold == '0' && t.role == "summary") || t.mementos.length == 0) {
+            if ((t.hammingdistancethreshold == '0' && t.role == "summary") || t.mementos.length == 0 || t.role == "histogram") {
                 callback('');
             } else {
                 t.calculateSimhashes(curCookieClientId,true,callback);
-            }
-        },
-        function(callback) {
-            if(update && t.mementos.length != 0) {
-                mementosFromMultipleURIs = mementosFromMultipleURIs.concat(t.mementos);
-                mementosFromMultipleURIs.sort(dateSort);
-                mementosFromMultipleURIs = getUnique(mementosFromMultipleURIs, "uri")
-
-                t.mementos = t.mementos.concat(fullCachedTimemap.mementos)
-                t.mementos.sort(dateSort);
-                t.mementos = getUnique(t.mementos, "uri");
-
-                callback('');
-            } else {
-                callback('');
             }
         },
         function (callback) {
@@ -870,6 +869,8 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
         function (callback) {
             if(t.hammingdistancethreshold == '0' && t.role == "summary" && t.mementos.length != 0) {
                 t.supplyAllMementosAScreenshotURI(callback);
+            }else if(t.role == "histogram") {
+                t.getDatesForHistogram(callback,response,curCookieClientId,true);
             } else if (t.mementos.length != 0) {
                 t.writeJSONToCache(callback);
             } else {
@@ -882,7 +883,7 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
                 ConsoleLogIfRequired(err);
             } else {
                 ConsoleLogIfRequired('There were no errors executing the callback chain');
-                if(!update && t.mementos.length != 0) {
+                if(t.mementos.length != 0) {
                     mementosFromMultipleURIs = mementosFromMultipleURIs.concat(t.mementos);
                 }
                 callback();
@@ -896,7 +897,7 @@ function getTimemapForMultipleURIs (uri, query, response, curCookieClientId, cal
 * @param fileContents JSON string consistenting of an array of mementos
 * @param response handler to client's browser interface
 */
-function processWithFileContents (uri, fileContents, response,curCookieClientId) {
+function processWithFileContents (uri, fileContents, response, curCookieClientId) {
     var t = createMementosFromJSONFile(fileContents);
     t.curClientId = curCookieClientId;
     t.originalURI = urlCanonicalize(response.thumbnails['urir']);
@@ -907,82 +908,80 @@ function processWithFileContents (uri, fileContents, response,curCookieClientId)
     /* ByMahee -- unnessessary for the current need
     t.printMementoInformation(response, null, false) */
 
-    if(response.thumbnails['from'] != 0) {
-        t.mementos = t.filterMementosForDateRange(response);
-    }
-
-    if(t.mementos.length < response.thumbnails['numMementos']) {
-        var fullCachedTimemap = createMementosFromJSONFile(fileContents);
-        fullCachedTimemap.curClientId = curCookieClientId;
-        fullCachedTimemap.originalURI = urlCanonicalize(response.thumbnails['urir']);
-        fullCachedTimemap.primesource = response.thumbnails['primesource'];
-        fullCachedTimemap.collectionidentifier = response.thumbnails['collectionidentifier'];
-        fullCachedTimemap.hammingdistancethreshold = response.thumbnails['hammingdistancethreshold'];
-        fullCachedTimemap.role = response.thumbnails['role'];
-        updateCache(fullCachedTimemap, t, uri,response, curCookieClientId);
-    } else if(t.mementos.length > response.thumbnails['numMementos']) {
-        matchMementosToArchive(t, uri, response, curCookieClientId);
-
+    if(t.mementos.simhash === 'undefined') {
+        getTimemapGodFunctionForAlSummarization(uri, response,curCookieClientId);
     } else {
-        if(t.mementos.simhash === 'undefined') {
-            getTimemapGodFunctionForAlSummarization(uri, response,curCookieClientId);
-        } else {
-            ConsoleLogIfRequired("Existing file contents are as follows:");
-            ConsoleLogIfRequired("**************************************************************************************************");
-            console.log(JSON.stringify(t));
-            if(isToComputeBoth) {
-                constructSSE('streamingStarted',curCookieClientId);
-                async.series([
-                    function (callback) {
-                        if(t.role == "stats") {
-                            t.calculateHammingDistancesWithOnlineFiltering(curCookieClientId,callback);
-                        } else if(t.role == "histogram") {
-                            callback('');
-                        }else{
-                            t.calculateHammingDistancesWithOnlineFilteringForSummary(curCookieClientId,callback);
-                        }
-                        constructSSE("percentagedone-5",curCookieClientId);
-                    },
-                    function (callback) {
-                        if(t.role == "stats") {
-                          t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURI(callback);
-                        } else if(t.role == "histogram") {
-                          callback('');
-                        } else {
-                          t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURIForSummary(callback);
-                        }
-                        constructSSE("percentagedone-15",curCookieClientId);
-                    },
-                    function (callback) {
-                        ConsoleLogIfRequired('****************curCookieClientId from processWithFileContents ->'+curCookieClientId +' *********');
-                        constructSSE("percentagedone-20",curCookieClientId);
-                        if (t.role == "histogram") {
-                            t.getDatesForHistogram(callback,response,curCookieClientId);
-                        } else {
-                            t.createScreenshotsForMementos(curCookieClientId,response,callback);
-                        }
-                    },
-                    function (callback) {
-                        constructSSE('Writing the data into cache file for future use...',curCookieClientId);
-                        constructSSE("percentagedone-95",curCookieClientId);
-                        if (t.role == "histogram") {
-                            callback('');
-                        } else {
-                            t.writeThumbSumJSONOPToCache(response);
-                        }
-                    }],
-                    function (err, result) {
-                        if (err) {
-                            console.log('ERROR!');
-                            console.log(err);
-                        } else {
-                            constructSSE('Finshed writing into cache...',curCookieClientId);
-                            constructSSE("percentagedone-100",curCookieClientId);
-                            console.log('There were no errors executing the callback chain');
-                        }
+        ConsoleLogIfRequired("Existing file contents are as follows:");
+        ConsoleLogIfRequired("**************************************************************************************************");
+        console.log(JSON.stringify(t));
+        if(isToComputeBoth) {
+            constructSSE('streamingStarted',curCookieClientId);
+            async.series([
+                function (callback) {
+                    if(response.thumbnails['from'] != 0) {
+                        t.filterMementosForDateRange(response, callback);
+                    } else {
+                        callback('');
                     }
-                );
-            }
+                },
+                function (callback) {
+                    if(t.mementos.length > maxMementos && t.role != "histogram") {
+                        t.filterMementos(response, curCookieClientId, callback)
+                    } else
+                        callback('');
+                },
+                function (callback) {
+                    t.matchMementosToArchive(uri, response, curCookieClientId, fileContents, callback);
+                },
+                function (callback) {
+                    if(t.role == "stats") {
+                        t.calculateHammingDistancesWithOnlineFiltering(curCookieClientId,callback);
+                    } else if(t.role == "histogram") {
+                        callback('');
+                    }else{
+                        t.calculateHammingDistancesWithOnlineFilteringForSummary(curCookieClientId,callback);
+                    }
+                    constructSSE("percentagedone-5",curCookieClientId);
+                },
+                function (callback) {
+                    if(t.role == "stats") {
+                      t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURI(callback);
+                    } else if(t.role == "histogram") {
+                      callback('');
+                    } else {
+                      t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURIForSummary(callback);
+                    }
+                    constructSSE("percentagedone-15",curCookieClientId);
+                },
+                function (callback) {
+                    ConsoleLogIfRequired('****************curCookieClientId from processWithFileContents ->'+curCookieClientId +' *********');
+                    constructSSE("percentagedone-20",curCookieClientId);
+                    if (t.role == "histogram") {
+                        t.getDatesForHistogram(callback,response,curCookieClientId, false);
+                    } else {
+                        t.createScreenshotsForMementos(curCookieClientId,response,callback);
+                    }
+                },
+                function (callback) {
+                    constructSSE('Writing the data into cache file for future use...',curCookieClientId);
+                    constructSSE("percentagedone-95",curCookieClientId);
+                    if (t.role == "histogram") {
+                        callback('');
+                    } else {
+                        t.writeThumbSumJSONOPToCache(response);
+                    }
+                }],
+                function (err, result) {
+                    if (err) {
+                        console.log('ERROR!');
+                        console.log(err);
+                    } else {
+                        constructSSE('Finshed writing into cache...',curCookieClientId);
+                        constructSSE("percentagedone-100",curCookieClientId);
+                        console.log('There were no errors executing the callback chain');
+                    }
+                }
+            );
         }
     }
 }
@@ -1150,18 +1149,25 @@ Memento.prototype.setSimhash = function (theTimeMap,curCookieClientId,notDateRan
 * @param fullCachedTimemap - timemap object that holds all mementos from cache file
 * @param t - timemap object that holds all cached mementos with a date range
 */
-function updateCache(fullCachedTimemap, t, uri, response, curCookieClientId) {
+TimeMap.prototype.updateCache = function(fullCachedTimemap, uri, response, curCookieClientId, callback) {
     ConsoleLogIfRequired("Inside updateCache()");
+    var t = this;
     var updatedTimemap = new TimeMap();
     async.series([
         function(callback) {
             updatedTimemap.fetchTimemap(uri, response, curCookieClientId, callback);
         },
         function(callback) {
-            if(response.thumbnails["from"] != 0) {
-                updatedTimemap.mementos = updatedTimemap.filterMementosForDateRange(response);
-            }
-            callback('');     
+            if(response.thumbnails["from"] != 0)
+                updatedTimemap.filterMementosForDateRange(response, callback);
+            else
+                callback('');     
+        },
+        function(callback) {
+            if(updatedTimemap.mementos.length > maxMementos && t.role != "histogram")
+                updatedTimemap.filterMementos(response, curCookieClientId, callback);
+            else
+                callback('');
         },
         function(callback) {
             //remove cached mementos
@@ -1175,37 +1181,24 @@ function updateCache(fullCachedTimemap, t, uri, response, curCookieClientId) {
             fullCachedTimemap.mementos = fullCachedTimemap.mementos.concat(updatedTimemap.mementos);
             fullCachedTimemap.mementos.sort(dateSort);
             fullCachedTimemap.mementos = getUnique(fullCachedTimemap.mementos,"uri");
-
+            console.log("\n*******************************"+t.mementos.length)
             t.mementos = t.mementos.concat(updatedTimemap.mementos);
             t.mementos.sort(dateSort);
             t.mementos = getUnique(t.mementos,"uri");
+            console.log(t.mementos.length)
             callback('');
+        },
+        function(callback) {
+            if(t.mementos.length > maxMementos && t.role != "histogram")
+                t.filterMementos(response, curCookieClientId, callback);
+            else
+                callback('');
         },
         function(callback) {
             fullCachedTimemap.saveSimhashesToCache(callback);
         },
-        function (callback) {
-            if(t.role == "stats") {
-                t.calculateHammingDistancesWithOnlineFiltering(curCookieClientId,callback);
-            }else{
-                t.calculateHammingDistancesWithOnlineFilteringForSummary(curCookieClientId,callback);
-            }
-        },
-        function (callback) {
-            if(t.role == "stats") {
-                t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURI(callback);
-            }else{
-                t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURIForSummary(callback);
-            }
-        },
         function(callback) {
             fullCachedTimemap.writeJSONToCache(callback);
-        },
-        function (callback) {
-            t.createScreenshotsForMementos(curCookieClientId,response,callback);
-        },
-        function (callback) {
-            t.SendThumbSumJSONCalledFromCache(response,callback);
         }],
         function (err, result) {
             if (err) {
@@ -1214,67 +1207,7 @@ function updateCache(fullCachedTimemap, t, uri, response, curCookieClientId) {
             } else {
                 ConsoleLogIfRequired('There were no errors executing the callback chain');
             }
-    });
-}
-
-/**
-* Executes if number of cached mementos are less that the number of mementos in the archives
-*
-* @param callback - The next procedure to execution when this process concludes
-*/
-function matchMementosToArchive(t, uri, response, curCookieClientId) {
-    ConsoleLogIfRequired("Inside matchMementosToArchive()");
-    async.series([
-        function(callback) {
-            t.deleteExtraMementos(callback);
-        },
-        function (callback) {
-            if(t.role == "stats") {
-                t.calculateHammingDistancesWithOnlineFiltering(curCookieClientId,callback);
-            }else{
-                t.calculateHammingDistancesWithOnlineFilteringForSummary(curCookieClientId,callback);
-            }
-        },
-        function (callback) {
-            if(t.role == "stats") {
-                t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURI(callback);
-            }else{
-                t.supplyChosenMementosBasedOnHammingDistanceAScreenshotURIForSummary(callback);
-            }
-        },
-        function (callback) {
-            t.createScreenshotsForMementos(curCookieClientId,response,callback);
-        },
-        function (callback) {
-            t.SendThumbSumJSONCalledFromCache(response,callback);
-        }],
-        function (err, result) {
-            if (err) {
-                ConsoleLogIfRequired('ERROR!');
-                ConsoleLogIfRequired(err);
-            } else {
-                ConsoleLogIfRequired('There were no errors executing the callback chain');
-            }
-    });
-}
-
-/**
-* Updates the cache files for multiple URI input.
-* 
-* @param uriList - The user input URIs
-*/
-function updateCacheForMultipleURIs(uriList, query, response, curCookieClientId, callback) {
-    async.eachLimit(uriList, 1, function(uri, callback) {
-        getTimemapForMultipleURIs(uri, query, response, curCookieClientId, callback, true);
-    },
-    function(err) {
-        if(err) {
-            console.log(err);
-            return;
-        }
-        if(callback) {
-            callback();
-        }
+            callback('');
     });
 }
 
@@ -1477,16 +1410,13 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
                         ConsoleLogIfRequired("-- ByMahee -- Mementos are created by this point, following is the whole timeMap Object");
                         //ConsoleLogIfRequired(t);
                         ConsoleLogIfRequired("---------------------------------------------------");
-                             
+
                         if (t.mementos.length === 0) {
                             ConsoleLogIfRequired('There were no mementos for ' + uri + ' :(');
                             response.write('There were no mementos for ' + uri + ' :(');
                             response.end();
                             return;
                         }
-                       
-                       if(t.mementos.length > 5000)
-                          t.filterMementos(curCookieClientId);
                                
                         if (t.mementos.length == 0) {
                             ConsoleLogIfRequired('There were no mementos in this date range:(');
@@ -1538,31 +1468,6 @@ TimeMap.prototype.fetchTimemap = function(uri, response, curCookieClientId, call
     }
 }
 
-TimeMap.prototype.filterMementos = function(curCookieClientId) {
-    var t = this;
-
-    var originalMemetosLengthFromTM = t.mementos.length;
-    // code segment to consider only last 1000 mementos for the huge TimeMaps
-    if(t.mementos.length > 5000) {
-        var tempMemetoArr=[];
-        var tempStackOfMementos = new Stack();
-        var numOfMementosToConsider = 5000; // only latest 5000 mementos are considered
-        for(var i = originalMemetosLengthFromTM-1; i>(originalMemetosLengthFromTM-numOfMementosToConsider-1); i--) {
-            tempStackOfMementos.push(t.mementos[i]);
-        }
-        for(var i=0;i< numOfMementosToConsider; i++) {
-            tempMemetoArr.push(tempStackOfMementos.pop());
-        }
-        constructSSE('The page you requested original has '+originalMemetosLengthFromTM +' Mementos, processing to consider only the mementos from date: [ '+JSON.parse(JSON.stringify(tempMemetoArr[0]))["datetime"] +' ] to date ['+JSON.parse(JSON.stringify(tempMemetoArr[tempMemetoArr.length-1]))["datetime"] + ']',curCookieClientId);
-        ConsoleLogIfRequired('The page you requested original has '+originalMemetosLengthFromTM +' Mementos, processing to consider only the mementos from date: [ '+JSON.parse(JSON.stringify(tempMemetoArr[0]))["datetime"] +' ] to date ['+JSON.parse(JSON.stringify(tempMemetoArr[tempMemetoArr.length-1]))["datetime"] + ']');
-        tempMemetoArr[0]["rel"] = "first memento";
-        t.mementos = tempMemetoArr;
-        ConsoleLogIfRequired("-----------Mementos under consideration, Length -> "+t.mementos.length +"  -------");
-        ConsoleLogIfRequired(JSON.stringify(t.mementos));
-        ConsoleLogIfRequired("---------------------------------------------------");
-    }
-}
-
 /**
 * Given a URI, return a TimeMap from the Memento Aggregator
 * TODO: God function that does WAY more than simply getting a timemap
@@ -1589,9 +1494,15 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
         // -- ByMahee -- Uncomment one by one for CLI_JSON
         function(callback) {
             if(response.thumbnails['from'] != 0) {
-                t.mementos = t.filterMementosForDateRange(response);
-            }
-            callback('');
+                t.filterMementosForDateRange(response, callback);
+            } else
+                callback('');
+        },
+        function(callback) {
+            if(t.mementos.length > maxMementos && t.role != "histogram") {
+                t.filterMementos(response, curCookieClientId, callback);
+            } else
+                callback('');
         },
         function (callback) {
             if (t.role == "histogram" || (t.hammingdistancethreshold == '0' && t.role == "summary")) {
@@ -1636,7 +1547,7 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
         },
         function (callback) {
             if(t.role == "histogram") {
-                t.getDatesForHistogram(callback,response,curCookieClientId);
+                t.getDatesForHistogram(callback,response,curCookieClientId, false);
             } else if(t.hammingdistancethreshold == '0' && t.role == "summary") {
                 t.supplyAllMementosAScreenshotURI(callback);
             } else {
@@ -1827,7 +1738,7 @@ TimeMap.prototype.writeJSONToCache = function (callback) {
 *
 * @param callback - The next procedure to execution when this process concludes
 */
-TimeMap.prototype.getDatesForHistogram = function (callback,response,curCookieClientId) {
+TimeMap.prototype.getDatesForHistogram = function (callback,response,curCookieClientId, isMultipleURIs) {
     var month_names_short= ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     var mementoDates=[];
     var length = this.mementos.length -1;
@@ -1847,34 +1758,117 @@ TimeMap.prototype.getDatesForHistogram = function (callback,response,curCookieCl
         var eventDisplayDate = dt.getUTCFullYear()+"-"+ month+"-"+date+", "+ memento["datetime"].split(" ")[4];*/
 
 
-        mementoDates.push(memento["datetime"]);
+        mementoDates.push(JSON.stringify(memento["datetime"]));
     });
     ConsoleLogIfRequired(mementoDates);
     ConsoleLogIfRequired("-------------------------------------------------------------------------");
 
-    var cacheFile = new SimhashCacheFile(this.primesource+"_"+this.collectionidentifier+"_"+this.originalURI,isDebugMode);
-    cacheFile.path = cacheFile.path.replace("simhashes", "histogram");
-    cacheFile.writeFileContentsAsJSON(JSON.stringify(mementoDates));
-    constructSSE("histoDataSent",curCookieClientId);
-    response.write(JSON.stringify(mementoDates));
-    response.end();
-    callback('');
+    if(isMultipleURIs) {
+        var cacheFile = new SimhashCacheFile(this.primesource+"_"+this.collectionidentifier+"_"+this.originalURI,isDebugMode);
+        cacheFile.path = cacheFile.path.replace("simhashes", "histogram");
+        cacheFile.writeFileContentsAsJSON(mementoDates);
+    } else if(isMultipleURIs == null) {
+        constructSSE("histoDataSent",curCookieClientId);
+        response.write(JSON.stringify(mementoDates));
+        response.end();
+    } else {
+        var cacheFile = new SimhashCacheFile(this.primesource+"_"+this.collectionidentifier+"_"+this.originalURI,isDebugMode);
+        cacheFile.path = cacheFile.path.replace("simhashes", "histogram");
+        cacheFile.writeFileContentsAsJSON(mementoDates);
+        constructSSE("histoDataSent",curCookieClientId);
+        response.write(JSON.stringify(mementoDates));
+        response.end();
+    }
+
+    if(callback)
+        callback('');
 }
 
 /**
 * Filters memento array to contain just the requested date interval
 */
-TimeMap.prototype.filterMementosForDateRange = function(response) {
+TimeMap.prototype.filterMementosForDateRange = function(response, callback) {
     ConsoleLogIfRequired("Inside filterMementosForDateRange()");
     var theFromDate = new Date(response.thumbnails['from']);
     var theToDate = new Date(response.thumbnails['to']);
 
-    var filtered = this.mementos.filter(function (curMemento) {
+    this.mementos = this.mementos.filter(function (curMemento) {
         var tryDate = new Date(curMemento.datetime);
         return tryDate >= theFromDate && tryDate <= theToDate;
     });
-    ConsoleLogIfRequired("Filtered memento array size: "+filtered.length);
-    return filtered;
+
+    if(archivedMementos != null) {
+        archivedMementos = archivedMementos.filter(function (curDate) {
+            return curDate >= theFromDate && curDate <= theToDate;
+        });   
+    }
+
+    if(callback)
+        callback('');
+}
+
+TimeMap.prototype.filterMementos = function(response, curCookieClientId, callback) {
+    var t = this;
+    var originalMemetosLengthFromTM = t.mementos.length;
+
+    // code segment to consider only last 1000 mementos for the huge TimeMaps
+    var tempMemetoArr=[];
+    var tempStackOfMementos = new Stack();
+    var tempStackArchived = new Stack();
+    var numOfMementosToConsider = maxMementos; // only latest 1000 mementos are considered
+
+    for(var i = originalMemetosLengthFromTM-1; i>(originalMemetosLengthFromTM-numOfMementosToConsider-1); i--) {
+        tempStackOfMementos.push(t.mementos[i]);
+    }
+    for(var i=0;i< numOfMementosToConsider; i++) {
+        tempMemetoArr.push(tempStackOfMementos.pop());
+    }
+
+    constructSSE('The page you requested original has '+originalMemetosLengthFromTM +' Mementos, processing to consider only the mementos from date: [ '+JSON.parse(JSON.stringify(tempMemetoArr[0]))["datetime"] +' ] to date ['+JSON.parse(JSON.stringify(tempMemetoArr[tempMemetoArr.length-1]))["datetime"] + ']',curCookieClientId);
+    ConsoleLogIfRequired('The page you requested original has '+originalMemetosLengthFromTM +' Mementos, processing to consider only the mementos from date: [ '+JSON.parse(JSON.stringify(tempMemetoArr[0]))["datetime"] +' ] to date ['+JSON.parse(JSON.stringify(tempMemetoArr[tempMemetoArr.length-1]))["datetime"] + ']');
+    tempMemetoArr[0]["rel"] = "first memento";
+    t.mementos = tempMemetoArr;
+    ConsoleLogIfRequired("-----------Mementos under consideration, Length -> "+t.mementos.length +"  -------");
+    ConsoleLogIfRequired(JSON.stringify(t.mementos));
+    ConsoleLogIfRequired("---------------------------------------------------");
+
+    tempMemetoArr=[];
+    if(response.thumbnails["from"] == 0 && archivedMementos != null) {
+        var originalMemetosLengthFromArchive = archivedMementos.length;
+        for(var i = originalMemetosLengthFromArchive-1; i>(originalMemetosLengthFromArchive-numOfMementosToConsider-1); i--) {
+            tempStackArchived.push(archivedMementos[i]);
+        }
+        for(var i=0;i< numOfMementosToConsider; i++) {
+            tempMemetoArr.push(tempStackArchived.pop());
+        }
+        //tempMemetoArr[0]["rel"] = "first memento";
+        archivedMementos = tempMemetoArr;
+    }
+
+    if(callback)
+        callback('');
+}
+
+TimeMap.prototype.matchMementosToArchive = function(uri, response, curCookieClientId, fileContents, callback) {
+    var histogramFile = new SimhashCacheFile(response.thumbnails["primesource"]+"_"+response.thumbnails["collectionidentifier"]+"_"+urlCanonicalize(uri),isDebugMode);
+    histogramFile.path = histogramFile.path.replace("simhashes","histogram");
+    histogramFile.path += ".json";
+    archivedMementos = JSON.parse(histogramFile.readFileContentsSync());
+
+    if(this.mementos.length < archivedMementos.length) {
+        var fullCachedTimemap = createMementosFromJSONFile(fileContents);
+        fullCachedTimemap.curClientId = curCookieClientId;
+        fullCachedTimemap.originalURI = urlCanonicalize(uri);
+        fullCachedTimemap.primesource = response.thumbnails['primesource'];
+        fullCachedTimemap.collectionidentifier = response.thumbnails['collectionidentifier'];
+        fullCachedTimemap.hammingdistancethreshold = response.thumbnails['hammingdistancethreshold'];
+        fullCachedTimemap.role = response.thumbnails['role'];
+        this.updateCache(fullCachedTimemap, uri, response, curCookieClientId, callback);
+    }
+    else if (this.mementos.length > archivedMementos.length)
+        this.deleteExtraMementos(callback);
+    else
+        callback('');
 }
 
 /**

--- a/tmvis.js
+++ b/tmvis.js
@@ -1561,9 +1561,6 @@ TimeMap.prototype.filterMementos = function(curCookieClientId) {
         ConsoleLogIfRequired(JSON.stringify(t.mementos));
         ConsoleLogIfRequired("---------------------------------------------------");
     }
-    if(uri.split(',').length > 1 && t.role == "histogram") {
-        t.mementos.sort(dateSort);
-    }
 }
 
 /**


### PR DESCRIPTION
* Histogram response saved to a cache file. Naming convention: histogram_[archive][collection Identifier][URI].
  * Histogram cache file is now used to update the cache and get mementos removed from the 
     archive. 
  * This process works well since the histogram always fetches data from the archives which means 
     that the histogram cache file will always be up to date.

* Updated filter mementos algorithm
   * Algorithm selects mementos that are at least 3 days apart from each other.
   * This is done to eliminate "similar" mementos which saves time in the simhash calculation.

* Fixed duplicate requests sent to server for URIs with large timemaps
  * The browser resends an executing request after a 2 minute window if no response is received.
  * FIX: Sending an empty response to keep the connection active and prevent a duplicate request.
  * Some timemaps take longer than 2 minutes when loading the stats page.
  * Summary page also uses this fix since in certain cases the user is may choose a large number of 
    screenshots that could take more than 2 minutes.