### PR TITLE
Urgent Bug Fix

### DIFF
--- a/tmvis.js
+++ b/tmvis.js
@@ -1805,7 +1805,7 @@ TimeMap.prototype.filterMementos = function(response, curCookieClientId, callbac
         else {
             currentTime = new Date(t.mementos[i]["datetime"].split(",")[1]).getTime();
             daysBetween = (currentTime - lastTime) / (1000*60*60*24);
-            if(daysBetween >= 3) { //If mementos are at least 7 days apart
+            if(daysBetween >= 3) { //If mementos are at least 3 days apart
                 console.log("Found one --------------------------------------------------- ");
                 console.log(i);
                 tempMementoArr.push(t.mementos[i]);

--- a/tmvis.js
+++ b/tmvis.js
@@ -1212,15 +1212,10 @@ TimeMap.prototype.deleteCachedMementos = function(cachedMementos, callback) {
 * @param callback - The next procedure to execution when this process concludes
 */
 TimeMap.prototype.deleteExtraMementos = function(callback) {
-    var cacheFile = new SimhashCacheFile(this.primesource+"_"+this.collectionidentifier+"_"+this.originalURI,isDebugMode);
-    cacheFile.path = cacheFile.path.replace("simhashes","histogram");
-    cacheFile.path += ".json";
-    var archiveMementos = JSON.parse(cacheFile.readFileContentsSync());
-    
-    if(archiveMementos != null) {
+    if(archivedMementos != null || archivedMementos.length > 0) {
         for(var i = 0; i < this.mementos.length; ++i) {
             var cachedDate = new Date(this.mementos[i].datetime);
-            var archiveDate = new Date(archiveMementos[i]);
+            var archiveDate = new Date(archivedMementos[i]);
             if(cachedDate.getTime() != archiveDate.getTime() || isNaN(archiveDate.getTime())) {
                 this.mementos.splice(i,1);
                 --i;
@@ -1461,6 +1456,13 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
         function (callback) {t.printMementoInformation(response, callback, false);}, // Return blank UI ASAP */
 
         // -- ByMahee -- Uncomment one by one for CLI_JSON
+        function(callback){
+        	if(t.role == "histogram") {
+        		t.getDatesForHistogram(callback,response,curCookieClientId, false);
+        	} else {
+        		t.getDatesForHistogram(callback,response,curCookieClientId, true);
+        	}
+        },
         function(callback) {
             if(response.thumbnails['from'] != 0) {
                 t.filterMementosForDateRange(response, callback);
@@ -1516,7 +1518,7 @@ function getTimemapGodFunctionForAlSummarization (uri, response,curCookieClientI
         },
         function (callback) {
             if(t.role == "histogram") {
-                t.getDatesForHistogram(callback,response,curCookieClientId, false);
+                callback('');
             } else if(t.hammingdistancethreshold == '0' && t.role == "summary") {
                 t.supplyAllMementosAScreenshotURI(callback);
             } else {
@@ -1767,7 +1769,8 @@ TimeMap.prototype.filterMementosForDateRange = function(response, callback) {
 
     if(archivedMementos != null) {
         archivedMementos = archivedMementos.filter(function (curDate) {
-            return curDate >= theFromDate && curDate <= theToDate;
+        	var tryDate = new Date(curDate);
+            return tryDate >= theFromDate && tryDate <= theToDate;
         });   
     }
 
@@ -1802,7 +1805,7 @@ TimeMap.prototype.filterMementos = function(response, curCookieClientId, callbac
         else {
             currentTime = new Date(t.mementos[i]["datetime"].split(",")[1]).getTime();
             daysBetween = (currentTime - lastTime) / (1000*60*60*24);
-            if(daysBetween >= 3) { //If mementos are at least 3 days apart
+            if(daysBetween >= 3) { //If mementos are at least 7 days apart
                 console.log("Found one --------------------------------------------------- ");
                 console.log(i);
                 tempMementoArr.push(t.mementos[i]);


### PR DESCRIPTION
* Current deployment crashing when a non cached URI request for date range of stat or summary role is issued.
* Inside of filterMementosForDateRange(), archivedMementos array is emptied instead of deleting mementos not in the date range. This is due to the current date compared was compared as a string instead of a Date object.
* Fixed minor bug that was not generating a histogram cache file in case of a non cached URI request of stat or summary role. This bug would possibly lead to a crash.